### PR TITLE
Update download.R

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -301,7 +301,7 @@ get_file_list = function(apikey, product_path,
   }
 
   # To date type
-  files_df$partition_key = as.Date(files_df$partition_key)
+  try({files_df$partition_key = as.Date(files_df$partition_key)})
   # Attach index
   files_df = data.frame(index = 1:nrow(files_df), files_df)
   # Backward compatibility


### PR DESCRIPTION
The new platform doesn't always return a properly formatted date in the partition key column, which creates problems in the get_file_list command. I updated the code by wrapping the line in a try statement.